### PR TITLE
Fix AttachmentColor to JSON

### DIFF
--- a/src/Web/Slack/Types/Message.hs
+++ b/src/Web/Slack/Types/Message.hs
@@ -1,6 +1,5 @@
 {-# LANGUAGE TemplateHaskell #-}
 {-# LANGUAGE OverloadedStrings #-}
-{-# LANGUAGE DeriveGeneric #-}
 
 module Web.Slack.Types.Message where
 
@@ -8,7 +7,6 @@ import Data.Aeson
 import Data.Aeson.TH
 import qualified Data.Text as T
 import Data.Time.Clock.POSIX
-import GHC.Generics
 import Web.Slack.Types.Base
 import Web.Slack.Types.Id
 import Web.Slack.Utils
@@ -85,7 +83,6 @@ data AttachmentColor
     | WarningColor       -- yellow
     | DangerColor        -- red
     | CustomColor T.Text -- hexadecimal RGB colour, eg. CustomColor "#439FE0"
-    deriving (Generic)
 
 defaultAttachment :: Attachment
 defaultAttachment = Attachment
@@ -107,7 +104,7 @@ defaultAttachment = Attachment
         }
 
 instance ToJSON AttachmentColor where
-    toEncoding x = toEncoding $ case x of
+    toJSON x = toJSON $ case x of
         DefaultColor  -> Nothing
         GoodColor     -> Just "good"
         WarningColor  -> Just "warning"

--- a/src/Web/Slack/Types/Message.hs
+++ b/src/Web/Slack/Types/Message.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE TemplateHaskell #-}
 {-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE DeriveGeneric #-}
 
 module Web.Slack.Types.Message where
 
@@ -7,6 +8,7 @@ import Data.Aeson
 import Data.Aeson.TH
 import qualified Data.Text as T
 import Data.Time.Clock.POSIX
+import GHC.Generics
 import Web.Slack.Types.Base
 import Web.Slack.Types.Id
 import Web.Slack.Utils
@@ -83,6 +85,7 @@ data AttachmentColor
     | WarningColor       -- yellow
     | DangerColor        -- red
     | CustomColor T.Text -- hexadecimal RGB colour, eg. CustomColor "#439FE0"
+    deriving (Generic)
 
 defaultAttachment :: Attachment
 defaultAttachment = Attachment


### PR DESCRIPTION
hi @mpickering . I found a issue.

When `AttachmentColor` is encoded in JSON, `color` become `{"tag":"GoodColor"}`.
I expect that `color` will be `"green"`

thanks!

<details><summary><b>Dependencies</b></summary>

```
$ stack --version
Version 1.4.0 x86_64
Compiled with:
- Cabal-1.24.2.0
- Glob-0.7.14
- HUnit-1.5.0.0
- MonadRandom-0.5.1
- QuickCheck-2.9.2
- SHA-1.6.4.2
- StateVar-1.1.0.4
- aeson-1.0.2.1
- aeson-compat-0.3.6
- annotated-wl-pprint-0.7.0
- ansi-terminal-0.6.2.3
- ansi-wl-pprint-0.6.7.3
- array-0.5.1.1
- asn1-encoding-0.9.4
- asn1-parse-0.9.4
- asn1-types-0.3.2
- async-2.1.1
- attoparsec-0.13.1.0
- auto-update-0.1.4
- base-4.9.1.0
- base-compat-0.9.1
- base-orphans-0.5.4
- base16-bytestring-0.1.1.6
- base64-bytestring-1.0.0.1
- bifunctors-5.4.1
- binary-0.8.3.0
- binary-tagged-0.1.4.2
- bitarray-0.0.1.1
- blaze-builder-0.4.0.2
- blaze-html-0.8.1.3
- blaze-markup-0.7.1.1
- byteable-0.1.1
- bytestring-0.10.8.1
- call-stack-0.1.0
- case-insensitive-1.2.0.7
- cereal-0.5.4.0
- clock-0.7.2
- comonad-5
- conduit-1.2.9
- conduit-extra-1.1.15
- connection-0.2.7
- constraints-0.9
- containers-0.5.7.1
- contravariant-1.4
- cookie-0.4.2.1
- cryptohash-0.11.9
- cryptohash-sha256-0.11.100.1
- cryptonite-0.21
- cryptonite-conduit-0.2.0
- data-default-class-0.1.2.0
- deepseq-1.4.2.0
- digest-0.0.1.2
- directory-1.3.0.0
- distributive-0.5.2
- dlist-0.8.0.2
- easy-file-0.2.1
- ed25519-0.0.5.0
- either-4.4.1.1
- enclosed-exceptions-1.0.2
- errors-2.1.3
- exceptions-0.8.3
- extra-1.5.1
- fail-4.9.0.0
- fast-logger-2.4.10
- file-embed-0.0.10
- filelock-0.1.0.1
- filepath-1.4.1.1
- free-4.12.4
- fsnotify-0.2.1
- generic-deriving-1.11.1
- generics-sop-0.2.4.0
- ghc-boot-th-8.0.2
- ghc-prim-0.5.0.0
- gitrev-1.2.0
- hackage-security-0.5.2.2
- hashable-1.2.5.0
- hastache-0.6.1
- hfsevents-0.1.6
- hit-0.6.3
- hourglass-0.2.10
- hpack-0.17.0
- hpc-0.6.0.3
- hspec-2.4.1
- hspec-core-2.4.1
- hspec-discover-2.4.1
- hspec-expectations-0.8.2
- hspec-smallcheck-0.4.2
- http-api-data-0.3.5
- http-client-0.5.5
- http-client-tls-0.3.4
- http-conduit-2.2.3
- http-types-0.9.1
- ieee754-0.8.0
- integer-gmp-1.0.0.1
- integer-logarithms-1.0.1
- lifted-async-0.9.1.1
- lifted-base-0.2.3.8
- logict-0.6.0.2
- memory-0.14.1
- microlens-0.4.7.0
- microlens-mtl-0.1.10.0
- mime-types-0.1.0.7
- mmorph-1.0.9
- monad-control-1.0.1.0
- monad-logger-0.3.20.1
- monad-loops-0.4.3
- monad-unlift-0.2.0
- mono-traversable-1.0.1.1
- mtl-2.2.1
- nats-1.1.1
- network-2.6.3.1
- network-uri-2.6.1.0
- old-locale-1.0.0.7
- old-time-1.1.0.3
- open-browser-0.2.1.0
- optparse-applicative-0.13.1.0
- optparse-simple-0.0.3
- parsec-3.1.11
- path-0.5.12
- path-io-1.2.2
- path-pieces-0.2.1
- patience-0.1.1
- pem-0.2.2
- persistent-2.6
- persistent-sqlite-2.6
- persistent-template-2.5.1.6
- pid1-0.1.0.1
- prelude-extras-0.4.0.3
- pretty-1.1.3.3
- primitive-0.6.1.0
- process-1.4.3.0
- profunctors-5.2
- project-template-0.2.0
- quickcheck-io-0.1.4
- random-1.1
- regex-applicative-0.3.3
- regex-applicative-text-0.1.0.1
- resource-pool-0.2.3.2
- resourcet-1.1.9
- retry-0.7.4.2
- rts-1.0
- safe-0.3.13
- safe-exceptions-0.1.4.0
- scientific-0.3.4.10
- semigroupoids-5.1
- semigroups-0.18.2
- setenv-0.1.1.3
- silently-1.2.5
- smallcheck-1.1.1
- socks-0.5.5
- split-0.2.3.1
- stm-2.4.4.1
- stm-chans-3.0.0.4
- store-0.3.1
- store-core-0.3
- streaming-commons-0.1.17
- syb-0.6
- system-fileio-0.3.16.3
- system-filepath-0.4.13.4
- tagged-0.8.5
- tar-0.5.0.3
- template-haskell-2.11.1.0
- temporary-1.2.0.4
- text-1.2.2.1
- text-binary-0.2.1.1
- text-metrics-0.2.0
- tf-random-0.5
- th-expand-syns-0.4.2.0
- th-lift-0.7.6
- th-lift-instances-0.1.11
- th-orphans-0.13.3
- th-reify-many-0.1.6
- th-utilities-0.2.0.1
- time-1.6.0.1
- time-locale-compat-0.1.1.3
- tls-1.3.9
- transformers-0.5.2.0
- transformers-base-0.4.4
- transformers-compat-0.5.1.4
- unexceptionalio-0.3.0
- unicode-transforms-0.2.1
- unix-2.7.2.1
- unix-compat-0.4.3.1
- unix-time-0.3.7
- unordered-containers-0.2.7.2
- uri-bytestring-0.2.2.1
- utf8-string-1.0.1.1
- uuid-types-1.0.3
- vector-0.11.0.0
- vector-algorithms-0.7.0.1
- vector-binary-instances-0.2.3.4
- void-0.7.1
- x509-1.6.5
- x509-store-1.6.2
- x509-system-1.6.4
- x509-validation-1.6.5
- yaml-0.8.21.2
- zip-archive-0.3.0.5
- zlib-0.6.1.2
- zlib-bindings-0.1.1.5
```

</defails>